### PR TITLE
remove test for esni as it is no longer supported

### DIFF
--- a/tests/test_speedify.py
+++ b/tests/test_speedify.py
@@ -75,11 +75,6 @@ class TestSpeedify(unittest.TestCase):
         for f in show_functions:
             self.assertTrue(f() != "" and not None)
 
-    def test_esni(self):
-        logging.debug("\n\nTesting esni settings...")
-        for b in [False, True]:
-            self.assertEqual(speedify.esni(b)["enableEsni"], b)
-
     def test_headercompression(self):
         logging.debug("\n\nTesting header compression settings...")
         for b in [False, True]:


### PR DESCRIPTION
ESNI support has been deprecated in the daemon for some time now.

The CLI documented that the ESNI option does nothing since August of this year. Cloudflare quietly removed support for ESNI, in favor of ECH, at some point well before that (was it '22?)

Testing for this value being reported as it was saved is no longer relevant.