### PR TITLE
Update the ratelimit API to match Speedify v15.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ speedify_settings = '''{"connectmethod" : "closest","encryption" : true, "jumbo"
     "startupconnect": true,    "transport":"auto","overflow_threshold": 30.0,
     "adapter_priority_ethernet" : "always","adapter_priority_wifi" : "always",
     "adapter_priority_cellular" : "secondary", "adapter_datalimit_daily_all" : 0,
-    "adapter_datalimit_monthly_all" : 0, "adapter_ratelimit" : {"upload_bps":0, "download_bps":0},
+    "adapter_datalimit_monthly_all" : 0, "adapter_ratelimit" : {"download_bps": 0, "upload_bps": 0},
     }'''
 
 #Apply settings

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ speedify_settings = '''{"connectmethod" : "closest","encryption" : true, "jumbo"
     "startupconnect": true,    "transport":"auto","overflow_threshold": 30.0,
     "adapter_priority_ethernet" : "always","adapter_priority_wifi" : "always",
     "adapter_priority_cellular" : "secondary", "adapter_datalimit_daily_all" : 0,
-    "adapter_datalimit_monthly_all" : 0, "adapter_ratelimit_all" : 0
+    "adapter_datalimit_monthly_all" : 0, "adapter_ratelimit" : {"upload_bps":0, "download_bps":0},
     }'''
 
 #Apply settings

--- a/speedify.py
+++ b/speedify.py
@@ -1192,9 +1192,9 @@ def adapter_encryption(adapterID: str, should_encrypt):
 
 
 @exception_wrapper("Failed to set adapter ratelimit")
-def adapter_ratelimit(adapterID: str, upload_bps: int = 0, download_bps: int = 0):
+def adapter_ratelimit(adapterID: str, download_bps: int = 0, upload_bps: int = 0):
     """
-    adapter_ratelimit(adapterID: str, upload_bps: int = 0, download_bps: int = 0)
+    adapter_ratelimit(adapterID: str, download_bps: int = 0, upload_bps: int = 0)
     Sets the ratelimit in bps on the adapter whose adapterID is provided
     (show_adapters is where you find the adapterIDs)
 
@@ -1206,7 +1206,7 @@ def adapter_ratelimit(adapterID: str, upload_bps: int = 0, download_bps: int = 0
     :type download_bps: int
     :returns:  dict -- :ref:`JSON adapter response <adapter-datalimit-daily>` from speedify.
     """
-    return _run_speedify_cmd(["adapter", "ratelimit", adapterID, str(upload_bps), str(download_bps)])
+    return _run_speedify_cmd(["adapter", "ratelimit", adapterID, str(download_bps), str(upload_bps)])
 
 
 @exception_wrapper("Failed to set adapter daily limit")

--- a/speedify.py
+++ b/speedify.py
@@ -1192,19 +1192,21 @@ def adapter_encryption(adapterID: str, should_encrypt):
 
 
 @exception_wrapper("Failed to set adapter ratelimit")
-def adapter_ratelimit(adapterID: str, ratelimit: int = 0):
+def adapter_ratelimit(adapterID: str, upload_bps: int = 0, download_bps: int = 0):
     """
-    adapter_ratelimit(adapterID: str, ratelimit: int = 0)
+    adapter_ratelimit(adapterID: str, upload_bps: int = 0, download_bps: int = 0)
     Sets the ratelimit in bps on the adapter whose adapterID is provided
     (show_adapters is where you find the adapterIDs)
 
     :param adapterID: The interface adapterID
     :type adapterID: str
-    :param ratelimit: The ratelimit in bps
-    :type ratelimit: int
+    :param upload_bps: The upload ratelimit in bps
+    :type upload_bps: int
+    :param download_bps: The download ratelimit in bps
+    :type download_bps: int
     :returns:  dict -- :ref:`JSON adapter response <adapter-datalimit-daily>` from speedify.
     """
-    return _run_speedify_cmd(["adapter", "ratelimit", adapterID, str(ratelimit)])
+    return _run_speedify_cmd(["adapter", "ratelimit", adapterID, str(upload_bps), str(download_bps)])
 
 
 @exception_wrapper("Failed to set adapter daily limit")

--- a/speedifysettings.py
+++ b/speedifysettings.py
@@ -22,7 +22,9 @@ speedify_defaults = (
     "startupconnect": true,  "packet_aggregation": true,  "transport":"auto","overflow_threshold": 30.0,
     "adapter_priority_ethernet" : "always","adapter_priority_wifi" : "always",
     "adapter_priority_cellular" : "secondary", "adapter_datalimit_daily_all" : 0,
-    "adapter_datalimit_monthly_all" : 0, "adapter_ratelimit_all" : 0, "route_default": true
+    "adapter_datalimit_monthly_all" : 0,
+    "adapter_ratelimit": {"upload_bps": 0, "download_bps": 0},
+    "route_default": true
     """
     + (
         ', "privacy_killswitch":false, "privacy_dnsleak": true,'
@@ -148,7 +150,10 @@ def get_speedify_settings():
         for adapter in adapters:
             logging.debug("Adapter is :" + str(adapter))
             adaptername = adapter["name"]
-            settings["adapter_ratelimit_" + adaptername] = adapter["rateLimit"]
+            settings["adapter_ratelimit_" + adaptername] = {
+                "upload_bps": adapter["rateLimit"]["uploadBps"],
+                "download_bps": adapter["rateLimit"]["downloadBps"],
+            }
             settings["adapter_priority_" + adaptername] = adapter["priority"]
             if "dataUsage" in adapter:
                 limits = adapter["dataUsage"]
@@ -262,4 +267,4 @@ def _apply_setting_to_adapters(setting, value, adapterguids):
             raise
     elif setting.startswith("adapter_ratelimit"):
         for guid in adapterguids:
-            speedify.adapter_ratelimit(guid, value)
+            speedify.adapter_ratelimit(guid, value["upload_bps"], value["download_bps"])

--- a/speedifysettings.py
+++ b/speedifysettings.py
@@ -267,4 +267,4 @@ def _apply_setting_to_adapters(setting, value, adapterguids):
             raise
     elif setting.startswith("adapter_ratelimit"):
         for guid in adapterguids:
-            speedify.adapter_ratelimit(guid, value["upload_bps"], value["download_bps"])
+            speedify.adapter_ratelimit(guid, value["download_bps"], value["upload_bps"])

--- a/tests/test_speedify.py
+++ b/tests/test_speedify.py
@@ -452,7 +452,7 @@ class TestSpeedify(unittest.TestCase):
     def _set_and_test_adapter_list(self, adapterIDs, priority, limit):
         for adapterID in adapterIDs:
             speedify.adapter_priority(adapterID, priority)
-            speedify.adapter_ratelimit(adapterID, limit)
+            speedify.adapter_ratelimit(adapterID, limit, limit)
             speedify.adapter_datalimit_daily(adapterID, limit)
             speedify.adapter_datalimit_monthly(adapterID, limit, 0)
         updated_adapters = speedify.show_adapters()
@@ -470,7 +470,8 @@ class TestSpeedify(unittest.TestCase):
             # Disconnected adapters speedify is aware of will have an unchangable priority never
             if set_priority != Priority.NEVER.value:
                 self.assertEqual(set_priority, priority.value)
-            self.assertEqual(rate_limit, limit)
+            self.assertEqual(rate_limit["uploadBps"], limit)
+            self.assertEqual(rate_limit["downloadBps"], limit)
             self.assertEqual(daily_limit, limit)
             self.assertEqual(monthly_limit, limit)
 


### PR DESCRIPTION
Tests passing on the rate limit cases, but failing in unrelated spots.

```
..2025-02-18 15:27:24,869	ERROR	speedify	Failed to connect: There were no servers found in your chosen country
...........E............
======================================================================
ERROR: test_routedefault (__main__.TestSpeedify.test_routedefault)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/edant/speedify-dev/speedify-py/tests/test_speedify.py", line 351, in test_routedefault
    if not speedifyutil.using_speedify():
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/edant/speedify-dev/speedify-py/tests/../speedifyutil.py", line 55, in using_speedify
    raise e
  File "/home/edant/speedify-dev/speedify-py/tests/../speedifyutil.py", line 52, in using_speedify
    result = subprocess.run(tracert, stdout=subprocess.PIPE, shell=use_shell())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1901, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'mtr'

----------------------------------------------------------------------
Ran 26 tests in 265.442s

FAILED (errors=1)
```

Separate issue.